### PR TITLE
Add trace system to nitc

### DIFF
--- a/clib/traces.c
+++ b/clib/traces.c
@@ -1,0 +1,5 @@
+#define TRACEPOINT_CREATE_PROBES
+#define TRACEPOINT_DEFINE
+
+#include "traces.h"
+

--- a/clib/traces.h
+++ b/clib/traces.h
@@ -4,8 +4,8 @@
 #undef TRACEPOINT_INCLUDE
 #define TRACEPOINT_INCLUDE "/home/olivier/Bureau/nit/src/nit_compile/traces.h"
 
-#if !defined(_HELLO_TP_H) || defined(TRACEPOINT_HEADER_MULTI_READ)
-#define _HELLO_TP_H
+#if !defined(_TRACES_H) || defined(TRACEPOINT_HEADER_MULTI_READ)
+#define _TRACES_H
 
 #include <lttng/tracepoint.h>
 
@@ -22,6 +22,6 @@ TRACEPOINT_EVENT(
     )
 )
 
-#endif /* _HELLO_TP_H */
+#endif
 
 #include <lttng/tracepoint-event.h>

--- a/clib/traces.h
+++ b/clib/traces.h
@@ -1,0 +1,27 @@
+#undef TRACEPOINT_PROVIDER
+#define TRACEPOINT_PROVIDER Nit_Compiler
+
+#undef TRACEPOINT_INCLUDE
+#define TRACEPOINT_INCLUDE "/home/olivier/Bureau/nit/src/nit_compile/traces.h"
+
+#if !defined(_HELLO_TP_H) || defined(TRACEPOINT_HEADER_MULTI_READ)
+#define _HELLO_TP_H
+
+#include <lttng/tracepoint.h>
+
+TRACEPOINT_EVENT(
+    Nit_Compiler,
+    Object_Instance,
+    TP_ARGS(
+        char*, object_class_arg,
+        int, object_id_arg
+    ),
+    TP_FIELDS(
+        ctf_string(object_class, object_class_arg)
+        ctf_integer(int, object_id, object_id_arg)
+    )
+)
+
+#endif /* _HELLO_TP_H */
+
+#include <lttng/tracepoint-event.h>

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -233,6 +233,11 @@ class MakefileToolchain
 		compiler.files_to_copy.add "{clib}/gc_chooser.c"
 		compiler.files_to_copy.add "{clib}/gc_chooser.h"
 
+		var traces = new ExternCFile("traces.c", "-llttng-ust -ldl")
+		compiler.extern_bodies.add(traces)
+		compiler.files_to_copy.add "{clib}/traces.c"
+		compiler.files_to_copy.add "{clib}/traces.h"
+
 		# FFI
 		for m in compiler.mainmodule.in_importation.greaters do
 			compiler.finalize_ffi_for_module(m)
@@ -374,6 +379,7 @@ CFLAGS ?= -g {{{if not debug then "-O2" else ""}}} -Wno-unused-value -Wno-switch
 CINCL =
 LDFLAGS ?=
 LDLIBS  ?= -lm {{{linker_options.join(" ")}}}
+LDLIBS += -llttng-ust -ldl
 \n"""
 
 		makefile.write "\n# SPECIAL CONFIGURATION FLAGS\n"
@@ -698,6 +704,7 @@ abstract class AbstractCompiler
 		self.header.add_decl("#include <string.h>")
 		# longjmp !
 		self.header.add_decl("#include <setjmp.h>\n")
+		self.header.add_decl("#include \"traces.h\"")
 		self.header.add_decl("#include <sys/types.h>\n")
 		self.header.add_decl("#include <unistd.h>\n")
 		self.header.add_decl("#include <stdint.h>\n")

--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -982,6 +982,7 @@ class SeparateCompiler
 				var alloc = v.nit_alloc("sizeof(struct instance) + {attrs.length}*sizeof(nitattribute_t)", mclass.full_name)
 				v.add("{res} = {alloc};")
 			end
+			v.add("tracepoint(Nit_Compiler, Object_Instance,\"{mtype}\", self);")
 			v.add("{res}->type = type;")
 			hardening_live_type(v, "type")
 			v.require_declaration("class_{c_name}")

--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -982,7 +982,7 @@ class SeparateCompiler
 				var alloc = v.nit_alloc("sizeof(struct instance) + {attrs.length}*sizeof(nitattribute_t)", mclass.full_name)
 				v.add("{res} = {alloc};")
 			end
-			v.add("tracepoint(Nit_Compiler, Object_Instance,\"{mtype}\", self);")
+			if modelbuilder.toolcontext.opt_trace.value then v.add("tracepoint(Nit_Compiler, Object_Instance,\"{mtype}\", (intptr_t)self);")
 			v.add("{res}->type = type;")
 			hardening_live_type(v, "type")
 			v.require_declaration("class_{c_name}")


### PR DESCRIPTION

To install lttng: https://lttng.org/docs/v2.10/#doc-installing-lttng

To compile using the trace system: add -t or --trace

To test tracing some instances : 
lttng create "Nom de la session"
lttng enable-event --userspace Nit_Compiler:Object_Instance
lttng start 
--> run your program 
lttng stop

To read your CTF trace file: 
babeltrace ~/lttng-traces/nom_de_la_session

define TRACEPOINT_INCLUDE "/home/olivier/Bureau/nit/src/nit_compile/traces.h"
This instruction is located into **traces.h**. You have to adapt it with your specific path. 
The dynamical version is the object of the next PR. 